### PR TITLE
Translate non recursive let to nontac expr when possible

### DIFF
--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -9,6 +9,7 @@ minibench.v
 compiler_bug_4.v
 compiler_bug_6.v
 compiler_bug_14.v
+compiler_bug_16.v
 compiler_bug_17.v
 
 -I src

--- a/tests/compiler_bug_16.v
+++ b/tests/compiler_bug_16.v
@@ -1,0 +1,7 @@
+From Ltac2 Require Import Ltac2 RedFlags.
+From Ltac2Compiler Require Import Ltac2Compiler.
+
+Ltac2 beta_iota :=
+  let x := RedFlags.all in x.
+
+Ltac2 Compile beta_iota.


### PR DESCRIPTION
Fix #16 (by being compatible with Tac2intern.is_value)

I'd like to have a more direct implementation than using `is_nontac` but it's not coming to me.